### PR TITLE
Add AudioQueue audio driver for macOS

### DIFF
--- a/audiodrivers/audioqueue/audioqueue.c
+++ b/audiodrivers/audioqueue/audioqueue.c
@@ -1,0 +1,82 @@
+// AudioQueue audio driver for ft2play on macOS
+
+#include <AudioToolbox/AudioQueue.h>
+#include <os/lock.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "../../pmp_mix.h"
+
+static AudioQueueRef aq;
+static os_unfair_lock lock = OS_UNFAIR_LOCK_INIT;
+
+static void audioCallback(void *userdata, AudioQueueRef queue, AudioQueueBufferRef buffer)
+{
+	os_unfair_lock_lock(&lock);
+	mix_UpdateBuffer((int16_t *)buffer->mAudioData, buffer->mAudioDataBytesCapacity / 4);
+	os_unfair_lock_unlock(&lock);
+
+	buffer->mAudioDataByteSize = buffer->mAudioDataBytesCapacity;
+	AudioQueueEnqueueBuffer(queue, buffer, 0, NULL);
+	(void)userdata;
+}
+
+void lockMixer(void)
+{
+	if (aq != 0)
+		os_unfair_lock_lock(&lock);
+}
+
+void unlockMixer(void)
+{
+	if (aq != 0)
+		os_unfair_lock_unlock(&lock);
+}
+
+bool openMixer(int32_t mixingFrequency, int32_t mixingBufferSize)
+{
+	AudioStreamBasicDescription desc;
+
+	if (aq != 0)
+		return true;
+
+	memset(&desc, 0, sizeof (desc));
+	desc.mFormatID = kAudioFormatLinearPCM;
+	desc.mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked;
+	desc.mSampleRate = mixingFrequency;
+	desc.mBitsPerChannel = 16;
+	desc.mBytesPerFrame = 4;
+	desc.mChannelsPerFrame = 2;
+	desc.mBytesPerPacket = 4;
+	desc.mFramesPerPacket = 1;
+
+	if (AudioQueueNewOutput(&desc, audioCallback, NULL, NULL, NULL, 0, &aq) != noErr)
+		return false;
+
+	int32_t bufferByteSize = 4 * mixingBufferSize;
+	for (int i = 0; i < 3; i++)
+	{
+		AudioQueueBufferRef buf;
+		if (AudioQueueAllocateBuffer(aq, bufferByteSize, &buf) != noErr)
+			goto openError;
+		memset(buf->mAudioData, 0, bufferByteSize);
+		buf->mAudioDataByteSize = bufferByteSize;
+		AudioQueueEnqueueBuffer(aq, buf, 0, NULL);
+	}
+
+	AudioQueueStart(aq, NULL);
+	return true;
+openError:
+	AudioQueueDispose(aq, true);
+	aq = 0;
+	return false;
+}
+
+void closeMixer(void) {
+	if (aq != 0)
+	{
+		AudioQueueStop(aq, true);
+		AudioQueueDispose(aq, true);
+		aq = 0;
+	}
+}

--- a/audiodrivers/audioqueue/audioqueue.h
+++ b/audiodrivers/audioqueue/audioqueue.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+void lockMixer(void);
+void unlockMixer(void);
+bool openMixer(int32_t mixingFrequency, int32_t mixingBufferSize);
+void closeMixer(void);

--- a/ft2play/make-macos-arm.sh
+++ b/ft2play/make-macos-arm.sh
@@ -4,9 +4,8 @@ echo Compiling arm64 binary, please wait...
 
 rm release/other/ft2play &> /dev/null
 
-clang -target arm64-apple-macos11 -mmacosx-version-min=11.0 -arch arm64 -march=armv8.3-a+sha3 -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks -g0 -DNDEBUG -DAUDIODRIVER_SDL ../audiodrivers/sdl/*.c ../*.c src/*.c -O3 -lm -Winit-self -Wno-deprecated -Wextra -Wunused -mno-ms-bitfields -Wno-missing-field-initializers -Wswitch-default -framework SDL2 -framework Cocoa -lm -o release/other/ft2play
+clang -target arm64-apple-macos11 -mmacosx-version-min=11.0 -arch arm64 -march=armv8.3-a+sha3 -g0 -DNDEBUG -DAUDIODRIVER_AUDIOQUEUE ../audiodrivers/audioqueue/*.c ../*.c src/*.c -O3 -Winit-self -Wno-deprecated -Wextra -Wunused -mno-ms-bitfields -Wno-missing-field-initializers -Wswitch-default -framework AudioToolbox -framework Cocoa -lm -o release/other/ft2play
 strip release/other/ft2play
-install_name_tool -change @rpath/SDL2.framework/Versions/A/SDL2 @executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2 release/other/ft2play
 
 rm ../*.o src/*.o &> /dev/null
 echo Done. The executable can be found in \'release/other\' if everything went well.

--- a/ft2play/make-macos-intel.sh
+++ b/ft2play/make-macos-intel.sh
@@ -4,9 +4,8 @@ echo Compiling 64-bit Intel binary, please wait...
 
 rm release/other/ft2play &> /dev/null
 
-clang -mmacosx-version-min=10.7 -arch x86_64 -mmmx -mfpmath=sse -msse2 -I/Library/Frameworks/SDL2.framework/Headers -F/Library/Frameworks -g0 -DNDEBUG -DAUDIODRIVER_SDL ../audiodrivers/sdl/*.c ../*.c src/*.c -O3 -lm -Winit-self -Wno-deprecated -Wextra -Wunused -mno-ms-bitfields -Wno-missing-field-initializers -Wswitch-default -framework SDL2 -framework Cocoa -lm -o release/other/ft2play
+clang -mmacosx-version-min=10.7 -arch x86_64 -mmmx -mfpmath=sse -msse2 -g0 -DNDEBUG -DAUDIODRIVER_AUDIOQUEUE ../audiodrivers/audioqueue/*.c ../*.c src/*.c -O3 -Winit-self -Wno-deprecated -Wextra -Wunused -mno-ms-bitfields -Wno-missing-field-initializers -Wswitch-default -framework AudioToolbox -framework Cocoa -lm -o release/other/ft2play
 strip release/other/ft2play
-install_name_tool -change @rpath/SDL2.framework/Versions/A/SDL2 @executable_path/../Frameworks/SDL2.framework/Versions/A/SDL2 release/other/ft2play
 
 rm ../*.o src/*.o &> /dev/null
 echo Done. The executable can be found in \'release/other\' if everything went well.

--- a/pmplay.h
+++ b/pmplay.h
@@ -8,6 +8,8 @@
 #include "audiodrivers/sdl/sdldriver.h"
 #elif defined AUDIODRIVER_WINMM
 #include "audiodrivers/winmm/winmm.h"
+#elif defined AUDIODRIVER_AUDIOQUEUE
+#include "audiodrivers/audioqueue/audioqueue.h"
 #else
 // Read "audiodrivers/how_to_write_drivers.txt"
 #endif


### PR DESCRIPTION
Use AudioQueue from system-builtin AudioToolbox framework. So no SDL2 needed on macOS.
I've tested the code on my Mac, both architectures. And it worked pretty well.